### PR TITLE
Adding PDF orientation flag

### DIFF
--- a/src/pdfkit_clj/core.clj
+++ b/src/pdfkit_clj/core.clj
@@ -13,7 +13,8 @@
                                 :margin {:top 10
                                          :right 10
                                          :bottom 10
-                                         :left 10}})
+                                         :left 10}
+                                :orientation "Portrait"})
 
 (defn- rand-tmp-file-name
   [tmp-dir]
@@ -57,10 +58,12 @@
 
 (defn gen-pdf
   "Produces a PDF file given an html string."
-  [html & {:keys [path tmp asset-path stylesheets margin]
-           :or {path (:path defaults) tmp (:tmp defaults)
+  [html & {:keys [path tmp asset-path stylesheets margin orientation]
+           :or {path (:path defaults) 
+                tmp (:tmp defaults)
                 asset-path (:asset-path defaults)
-                margin {}}}]
+                margin {}
+                orientation (:orientation defaults)}}]
   (let [margin (merge (:margin defaults) margin)
         tmp-file-name (rand-tmp-file-name tmp)
         stylesheets (map #(io/resource (str asset-path "/" %))
@@ -72,6 +75,7 @@
     (sh path
         "-T" (top* margin) "-R" (right* margin)
         "-B" (bottom* margin) "-L" (left* margin)
+        "-O" orientation
         "-" tmp-file-name :in html)
     (io/as-file tmp-file-name)))
 


### PR DESCRIPTION
A project I'm currently working on requires HTML tables to be displayed in Landscape orientation.
wkhtmltopdf allows the option to change the orientation of the PDF file via a flag, `-O`, with the options being `Portrait` or `Landscape`.

I've added this as an option with the default staying as Portrait.
